### PR TITLE
Use .env for GitHub configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+GITHUB_TOKEN=your_personal_access_token
+GITHUB_REPOSITORY=technikly/outlook2github
+GITHUB_BRANCH=main
+GITHUB_PATH=calendars/combined.ics
+GITHUB_COMMIT_MSG=Automated update of merged calendar

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore environment files containing secrets
+.env
+
+# Python cache
+__pycache__/


### PR DESCRIPTION
## Summary
- load GitHub token, repository and other settings from environment variables
- provide `.env.example` and ignore real `.env` files

## Testing
- `pip install requests python-dotenv` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python -m py_compile push_to_github.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd81a204c88322968ce3513d95d7e1